### PR TITLE
feat: Pass through directory options to `typed-css-modules`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ new TypedCSSModulesPlugin({
 
 This field is optional. When set to `true` the CSS field definitions will be emitted using camel case naming conventions. When `undefined` or `false` the CSS field definitions will be emitted verbatim.
 
+## `rootDir?: string`
+
+This field is optional. Project root directory (default: `process.cwd()`).
+
+## `searchDir?: string`
+
+This field is optional. Directory which includes target `*.css` files (default: `'./'`).
+
+## `outDir?: string`
+
+This field is optional. Output directory (default: `option.searchDir`).
+
 # License
 
 Copyright (c) 2018 Dropbox, Inc.

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,9 @@ export interface Options {
     | Array<PostCssPlugin<any>>
     | ((defaults: ReadonlyArray<PostCssPlugin<any>>) => PostCssPlugin<any>[]);
   readonly camelCase?: boolean;
+  readonly rootDir?: string;
+  readonly searchDir?: string;
+  readonly outDir?: string;
 }
 
 export class TypedCssModulesPlugin implements Tapable.Plugin {
@@ -53,13 +56,22 @@ export class TypedCssModulesPlugin implements Tapable.Plugin {
   private useIncremental = false;
   private globPattern: string;
 
-  constructor({globPattern, postCssPlugins = cssModuleCore.defaultPlugins, camelCase}: Options) {
+  constructor({
+    globPattern,
+    postCssPlugins = cssModuleCore.defaultPlugins,
+    camelCase,
+    rootDir,
+    searchDir,
+    outDir,
+  }: Options) {
     this.globPattern = globPattern;
     if (typeof postCssPlugins === 'function') {
       postCssPlugins = postCssPlugins(cssModuleCore.defaultPlugins);
     }
     this.dtsCreator = new DtsCreator({
-      searchDir: __dirname,
+      rootDir,
+      searchDir,
+      outDir,
       loaderPlugins: postCssPlugins,
       camelCase,
     });


### PR DESCRIPTION
Would like the ability to pass through the various directory options as provided in `typed-css-modules`:
https://github.com/Quramy/typed-css-modules/blob/master/README.md#new-dtscreatoroption